### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -35,7 +35,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build and publish Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: farao/gridcapa-cse-valid-adapter
           username: farao

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: mvn --batch-mode -Pdefault,coverage clean install
 
       - name: Build and publish Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: farao/gridcapa-cse-valid-adapter
           username: farao


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore